### PR TITLE
feat: add ignore_rendering option to skip JavaScript rendering during…

### DIFF
--- a/backend/core/consts.py
+++ b/backend/core/consts.py
@@ -23,6 +23,7 @@ OPTIONS_SCHEMA = {
                 "allowed_domains": {"type": "array", "items": {"type": "string"}},
                 "exclude_paths": {"type": "array", "items": {"type": "string"}},
                 "include_paths": {"type": "array", "items": {"type": "string"}},
+                "ignore_rendering": {"type": "boolean"},
             },
         },
         "map_options": {"type": "object", "properties": {}},

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -62,6 +62,7 @@ class SpiderOptionSerializer(serializers.Serializer):
         child=serializers.CharField(), required=False, default=[]
     )
     proxy_server = serializers.CharField(required=False, allow_null=True, default=None)
+    ignore_rendering = serializers.BooleanField(required=False, default=False)
 
     def validate_proxy_server(self, value):
         if (
@@ -124,6 +125,7 @@ class BatchSpiderOptionSerializer(SpiderOptionSerializer):
     allowed_domains = serializers.HiddenField(default=[])
     exclude_paths = serializers.HiddenField(default=[])
     include_paths = serializers.HiddenField(default=[])
+    ignore_rendering = serializers.HiddenField(default=False)
 
 
 class BatchCrawlOptionSerializer(CrawlOptionSerializer):

--- a/backend/core/services.py
+++ b/backend/core/services.py
@@ -232,6 +232,10 @@ class CrawlHelpers(BaseHelpers):
         for item in settings.WATERCRAWL_PLUGINS:
             plugin = load_class_by_name(item)
             yield plugin
+    
+    @cached_property
+    def ignore_rendering(self):
+        return self.crawl_request.options.get("spider_options", {}).get("ignore_rendering", False)
 
 
 class SearchHelpers(BaseHelpers):
@@ -712,6 +716,7 @@ class CrawlerService:
             "exclude_paths": [],
             "include_paths": [],
             "proxy_server": None,
+            "ignore_rendering": False,
         }
 
         default_page_options = {

--- a/docs/docs/api/crawl-requests.md
+++ b/docs/docs/api/crawl-requests.md
@@ -35,7 +35,8 @@ Start a new web crawling operation with specified options.
       "page_limit": 100,
       "allowed_domains": ["example.com"],
       "exclude_paths": ["/private/*"],
-      "include_paths": ["/blog/*"]
+      "include_paths": ["/blog/*"],
+      "ignore_rendering": false
     },
     "page_options": {
       "exclude_tags": ["nav", "footer", "aside"],
@@ -68,6 +69,7 @@ Start a new web crawling operation with specified options.
 | allowed_domains | array | List of allowed domains to crawl | [] |
 | exclude_paths | array | List of paths to exclude | [] |
 | include_paths | array | List of paths to include | [] |
+| ignore_rendering | boolean | Ignore rendering | false |
 
 ##### Page Options
 
@@ -145,7 +147,8 @@ Retrieve details of a specific crawl request.
       "page_limit": 100,
       "allowed_domains": ["example.com"],
       "exclude_paths": ["/private/*"],
-      "include_paths": ["/blog/*"]
+      "include_paths": ["/blog/*"],
+      "ignore_rendering": false
     },
     "page_options": {
       "exclude_tags": ["nav", "footer", "aside"],
@@ -335,3 +338,5 @@ All endpoints may return the following error responses:
 3. **Error Handling**: Always check the status of your crawl requests and implement proper error handling.
 4. **Content Extraction**: Use `exclude_tags` and `include_tags` to precisely target the content you need.
 5. **Domain Restrictions**: Use `allowed_domains` to prevent the crawler from accessing unintended domains.
+6. **Ignore Rendering**: Use `ignore_rendering` to prevent the crawler from rendering a JS-heavy page.
+

--- a/docs/docs/api/create-crawl.md
+++ b/docs/docs/api/create-crawl.md
@@ -29,7 +29,8 @@ crawl = client.create_crawl_request(
         "page_limit": 100,
         "allowed_domains": ["example.com"],
         "exclude_paths": ["/private/*"],
-        "include_paths": ["/blog/*"]
+        "include_paths": ["/blog/*"],
+        "ignore_rendering": False,
     },
     page_options={
         "exclude_tags": ["nav", "footer", "aside"],
@@ -57,7 +58,8 @@ curl -X POST "https://api.watercrawl.dev/api/v1/core/crawl-requests/" \
         "page_limit": 100,
         "allowed_domains": ["example.com"],
         "exclude_paths": ["/private/*"],
-        "include_paths": ["/blog/*"]
+        "include_paths": ["/blog/*"],
+        "ignore_rendering": false,
       },
       "page_options": {
         "exclude_tags": ["nav", "footer", "aside"],
@@ -114,6 +116,7 @@ console.log(`Crawl started with ID: ${crawl.uuid}`);
 | allowed_domains | array | List of domains to crawl (support star pattern `*.example.com`) |
 | exclude_paths | array | URL patterns to exclude (support star pattern `blog/*`) |
 | include_paths | array | URL patterns to include (support star pattern `blog/*`) |
+| ignore_rendering | boolean | Ignore rendering | false |
 
 ### Page Options
 
@@ -141,7 +144,8 @@ console.log(`Crawl started with ID: ${crawl.uuid}`);
           'page_limit': 100,
           'allowed_domains': ['example.com'],
           'exclude_paths': ['/private/*'],
-          'include_paths': ['/blog/*']
+          'include_paths': ['/blog/*'],
+          'ignore_rendering': False,
       },
       'page_options': {
           'exclude_tags': ['nav', 'footer', 'aside'],
@@ -170,7 +174,8 @@ console.log(`Crawl started with ID: ${crawl.uuid}`);
       "page_limit": 100,
       "allowed_domains": ["example.com"],
       "exclude_paths": ["/private/*"],
-      "include_paths": ["/blog/*"]
+      "include_paths": ["/blog/*"],
+      "ignore_rendering": false,
     },
     "page_options": {
       "exclude_tags": ["nav", "footer", "aside"],
@@ -199,7 +204,8 @@ console.log(`Crawl started with ID: ${crawl.uuid}`);
           'page_limit': 100,
           'allowed_domains': ['example.com'],
           'exclude_paths': ['/private/*'],
-          'include_paths': ['/blog/*']
+          'include_paths': ['/blog/*'],
+          'ignore_rendering': false,
       },
       'page_options': {
           'exclude_tags': ['nav', 'footer', 'aside'],

--- a/docs/docs/api/get-crawl.md
+++ b/docs/docs/api/get-crawl.md
@@ -65,7 +65,8 @@ console.log(`Documents Found: ${crawl.number_of_documents}`);
             'page_limit': 100,
             'allowed_domains': ['example.com'],
             'exclude_paths': ['/private/*'],
-            'include_paths': ['/blog/*']
+            'include_paths': ['/blog/*'],
+            'ignore_rendering': False,
         },
         'page_options': {
             'exclude_tags': ['nav', 'footer', 'aside'],
@@ -97,7 +98,8 @@ console.log(`Documents Found: ${crawl.number_of_documents}`);
             "page_limit": 100,
             "allowed_domains": ["example.com"],
             "exclude_paths": ["/private/*"],
-            "include_paths": ["/blog/*"]
+            "include_paths": ["/blog/*"],
+            "ignore_rendering": False,
         },
         "page_options": {
             "exclude_tags": ["nav", "footer", "aside"],
@@ -129,7 +131,8 @@ console.log(`Documents Found: ${crawl.number_of_documents}`);
             page_limit: 100,
             allowed_domains: ['example.com'],
             exclude_paths: ['/private/*'],
-            include_paths: ['/blog/*']
+            include_paths: ['/blog/*'],
+            ignore_rendering: false,
         },
         page_options: {
             exclude_tags: ['nav', 'footer', 'aside'],

--- a/docs/docs/api/overview.md
+++ b/docs/docs/api/overview.md
@@ -103,3 +103,5 @@ Search requests have the same status values:
 3. **Error Handling**: Always check the status of your crawl requests and implement proper error handling.
 4. **Content Extraction**: Use `exclude_tags` and `include_tags` to precisely target the content you need.
 5. **Domain Restrictions**: Use `allowed_domains` to prevent the crawler from accessing unintended domains.
+6. **Ignore Rendering**: Use `ignore_rendering` to prevent the crawler from rendering a JS-heavy page.
+

--- a/docs/docs/clients/nodejs.md
+++ b/docs/docs/clients/nodejs.md
@@ -88,7 +88,8 @@ const request = await client.createCrawlRequest(
         page_limit: 1, // maximum number of pages to crawl
         allowed_domains: [], // allowed domains to crawl
         exclude_paths: [], // exclude paths
-        include_paths: [] // include paths
+        include_paths: [], // include paths
+        ignore_rendering: false, // ignore rendering
     },
     {
         exclude_tags: [], // exclude tags from the page

--- a/docs/docs/clients/php.md
+++ b/docs/docs/clients/php.md
@@ -83,7 +83,8 @@ $request = $client->createCrawlRequest(
         'page_limit' => 1, // maximum number of pages to crawl
         'allowed_domains' => [], // allowed domains to crawl
         'exclude_paths' => [], // exclude paths
-        'include_paths' => [] // include paths
+        'include_paths' => [], // include paths
+        'ignore_rendering' => false // ignore rendering
     ],
     [
         'exclude_tags' => [], // exclude tags from the page

--- a/docs/docs/clients/python.md
+++ b/docs/docs/clients/python.md
@@ -86,7 +86,8 @@ request = client.create_crawl_request(
         "page_limit": 1, # maximum number of pages to crawl
         "allowed_domains": [], # allowed domains to crawl
         "exclude_paths": [], # exclude paths
-        "include_paths": [] # include paths
+        "include_paths": [], # include paths
+        "ignore_rendering": False # ignore rendering
     },
     page_options={
         "exclude_tags": [], # exclude tags from the page

--- a/frontend/src/components/crawl/CrawlForm.tsx
+++ b/frontend/src/components/crawl/CrawlForm.tsx
@@ -66,6 +66,7 @@ export const CrawlForm: React.FC<CrawlFormProps> = ({ initialRequest, onCrawlEve
     excludePaths: [],
     includePaths: [],
     proxy_server: null,
+    ignore_rendering: false,
   });
 
   const [crawlStatus, setCrawlStatus] = useState<CrawlState>({
@@ -98,6 +99,7 @@ export const CrawlForm: React.FC<CrawlFormProps> = ({ initialRequest, onCrawlEve
           excludePaths: spider_options.exclude_paths || [],
           includePaths: spider_options.include_paths || [],
           proxy_server: spider_options.proxy_server,
+          ignore_rendering: spider_options.ignore_rendering,
         });
       }
 
@@ -149,6 +151,7 @@ export const CrawlForm: React.FC<CrawlFormProps> = ({ initialRequest, onCrawlEve
             exclude_paths: spiderOptions.excludePaths,
             include_paths: spiderOptions.includePaths,
             proxy_server: spiderOptions.proxy_server,
+            ignore_rendering: spiderOptions.ignore_rendering,
           }),
         },
         page_options: {

--- a/frontend/src/components/forms/SpiderOptionsForm.tsx
+++ b/frontend/src/components/forms/SpiderOptionsForm.tsx
@@ -8,7 +8,7 @@ import { UsableProxy } from '../../types/proxy';
 import ComboboxComponent from '../shared/ComboboxComponent';
 import { useTeam } from '../../contexts/TeamContext';
 import { capFirst } from '../../utils/formatters';
-
+import { Switch } from '@headlessui/react';
 export interface SpiderOptions {
   maxDepth: string;
   pageLimit: string;
@@ -16,10 +16,12 @@ export interface SpiderOptions {
   excludePaths: string[];
   includePaths: string[];
   proxy_server: string | null;
+  ignore_rendering?: boolean;
 }
 
 interface BatchSpiderOptions {
   proxy_server: string | null;
+  ignore_rendering?: boolean;
 }
 
 interface SpiderOptionsFormProps {
@@ -324,8 +326,33 @@ export const SpiderOptionsForm: React.FC<SpiderOptionsFormProps> = ({ options, o
             </div>
           </OptionGroup>
         </div>
-
         <div>
+        <div className="space-y-1">
+  <div className="flex items-center justify-between">
+    <label htmlFor="ignore-rendering" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+      Ignore Rendering
+      <span className="text-gray-500 text-xs ml-1">(Faster, no JavaScript)</span>
+    </label>
+    <Switch
+      checked={options.ignore_rendering || false}
+      onChange={(checked) => onChange({ ignore_rendering: checked })}
+      className={`${
+        options.ignore_rendering ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-600'
+      } relative inline-flex h-6 w-11 items-center rounded-full`}
+    >
+      <span className="sr-only">Ignore Rendering</span>
+      <span
+        className={`${
+          options.ignore_rendering ? 'translate-x-6' : 'translate-x-1'
+        } inline-block h-4 w-4 transform rounded-full bg-white transition`}
+      />
+    </Switch>
+  </div>
+  <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5 mb-1">
+    When enabled, uses faster HTTP requests without JavaScript rendering. Disable for JavaScript-heavy sites.
+  </p>
+</div>
+<br />
           <OptionGroup
             title="Proxy Settings"
             description="Configure proxy servers for your crawl requests"

--- a/frontend/src/types/crawl.ts
+++ b/frontend/src/types/crawl.ts
@@ -78,6 +78,7 @@ export interface SpiderOptions {
   exclude_paths?: string[];
   include_paths?: string[];
   proxy_server: string | null;
+  ignore_rendering?: boolean;
 }
 
 export interface CrawlOptions {


### PR DESCRIPTION
## Description
This pull request introduces a new feature to support the `ignore_rendering` option across the backend, frontend, and documentation. The `ignore_rendering` option allows users to skip JavaScript rendering during web crawling, improving performance for non-JavaScript-heavy sites. Below is a summary of the most important changes grouped by theme.

## Related Issue
Fixes # Or Resolves #](https://github.com/watercrawl/WaterCrawl/issues/84)

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update


## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performve performed a ed a self-review of my code
- [ ] I have made corresponding changes to the documentation