### PR TITLE
chore(docker): upgrade mcp image to v1.2.0 and update local compose config

### DIFF
--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -60,9 +60,8 @@ services:
       - "${PLAYWRIGHT_PORT:-8800}:${PLAYWRIGHT_PORT:-8800}"
 
   mcp:
-    image: watercrawl/mcp:v1.1.0
+    image: watercrawl/mcp:v1.2.0
     restart: always
-    platform: linux/amd64
     command: [ "sse", "--base-url", "${MCP_BACKEND_BASE_URL:-http://host.docker.internal:8000}", '--port', "${MCP_PORT:-8801}", '--endpoint', '/sse' ]
     ports:
       - "${MCP_PORT:-8801}:${MCP_PORT:-8801}"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -185,7 +185,7 @@ services:
       retries: 5
 
   mcp:
-    image: watercrawl/mcp:v1.1.0
+    image: watercrawl/mcp:v1.2.0
     restart: always
     command: [ "sse", "--base-url", "http://app", '--port', '3000', '--endpoint', '/sse' ]
 


### PR DESCRIPTION
## Description
- Bump watercrawl/mcp service image from v1.1.0 to v1.2.0 in both docker-compose.yml and docker-compose.local.yml
- Remove explicit platform specification from local compose file for mcp


## Related Issue
N/A

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## UI Changes
N/A

## Testing
N/A

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
