### PR TITLE
feat: replace dynamic config.js version with build-time version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WaterCrawl.dev</title>
     <!-- Load runtime configuration before the app (no-cache) -->
-    <script src="/config.js?v=${Date.now()}"></script>
+    <script src="/config.js?v=%VITE_APP_VERSION%"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig(({ mode }) => {
   // By default, only env variables prefixed with `VITE_` are exposed.
   // We need to load all env vars for Sentry plugin configuration.
   const env = loadEnv(mode, process.cwd(), '');
-  
+
   const sentryEnabled =
     !!env.SENTRY_AUTH_TOKEN &&
     !!env.SENTRY_ORG &&
@@ -23,13 +23,19 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [
-      react(), 
+      {
+        name: 'html-random-version',
+        transformIndexHtml(html: string) {
+          return html.replace('%VITE_APP_VERSION%', env.VITE_APP_VERSION || 'local');
+        },
+      },
+      react(),
       sentryEnabled && sentryVitePlugin({
         org: env.SENTRY_ORG,
         project: env.SENTRY_PROJECT,
         authToken: env.SENTRY_AUTH_TOKEN,
         release: {
-          name: env.VITE_APP_VERSION || 'development',
+          name: env.VITE_APP_VERSION || 'local',
         },
         sourcemaps: {
           assets: "./dist/**",


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replace dynamic runtime version with build-time version injection

- Add Vite plugin to inject version at build time into HTML

- Change config.js cache-busting from timestamp to app version

- Update Sentry release name fallback from 'development' to 'local'


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build Process"] -->|"VITE_APP_VERSION"| B["HTML Plugin"]
  B -->|"Inject Version"| C["index.html"]
  C -->|"config.js?v=VERSION"| D["Runtime Config"]
  A -->|"Set Release"| E["Sentry Plugin"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vite.config.ts</strong><dd><code>Add build-time version injection plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/vite.config.ts

<ul><li>Add custom Vite plugin <code>html-random-version</code> to inject <code>VITE_APP_VERSION</code> <br>into HTML<br> <li> Plugin replaces <code>%VITE_APP_VERSION%</code> placeholder in index.html during <br>build<br> <li> Update Sentry release name fallback from 'development' to 'local'<br> <li> Minor whitespace cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/watercrawl/WaterCrawl/pull/158/files#diff-97c6e2c429ec483132c584137a18a1ade2ff6c3f4f6485f4a83db604d0323d7c">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Replace dynamic timestamp with version placeholder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/index.html

<ul><li>Replace dynamic timestamp-based cache-busting with build-time version <br>variable<br> <li> Change config.js script src from <code>/config.js?v=${Date.now()}</code> to <br><code>/config.js?v=%VITE_APP_VERSION%</code><br> <li> Version is now injected at build time instead of runtime</ul>


</details>


  </td>
  <td><a href="https://github.com/watercrawl/WaterCrawl/pull/158/files#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

