### PR TITLE
chore: update Django to version 5.2.8

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -865,14 +865,14 @@ files = [
 
 [[package]]
 name = "django"
-version = "5.2.7"
+version = "5.2.8"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "django-5.2.7-py3-none-any.whl", hash = "sha256:59a13a6515f787dec9d97a0438cd2efac78c8aca1c80025244b0fe507fe0754b"},
-    {file = "django-5.2.7.tar.gz", hash = "sha256:e0f6f12e2551b1716a95a63a1366ca91bbcd7be059862c1b18f989b1da356cdd"},
+    {file = "django-5.2.8-py3-none-any.whl", hash = "sha256:37e687f7bd73ddf043e2b6b97cfe02fcbb11f2dbb3adccc6a2b18c6daa054d7f"},
+    {file = "django-5.2.8.tar.gz", hash = "sha256:23254866a5bb9a2cfa6004e8b809ec6246eba4b58a7589bc2772f1bcc8456c7f"},
 ]
 
 [package.dependencies]
@@ -3621,4 +3621,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4"
-content-hash = "9cc9edfa8cd08b44b5cfa8a576bda1aa7d4a23e4b0710665217569bcc061a42e"
+content-hash = "1a3146a16bdf88aa0aaa295286d6f325bad4abd8026d64971594b30ffd65b621"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,7 +9,7 @@ readme = "../README.md"
 requires-python = ">=3.13,<4"
 dependencies = [
     "gunicorn (==23.0.0)",
-    "django (==5.2.7)",
+    "django (==5.2.8)",
     "django-environ (==0.11.2)",
     "scrapy (==2.13.3)",
     "djangorestframework (==3.15.2)",


### PR DESCRIPTION
### **Auto-created Ticket**

[#171](https://github.com/watercrawl/WaterCrawl/issues/171)

### **PR Type**
Enhancement


___

### **Description**
- Update Django dependency from 5.2.7 to 5.2.8

- Includes latest Django patch release with bug fixes


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump Django to version 5.2.8</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/pyproject.toml

<ul><li>Updated Django version constraint from 5.2.7 to 5.2.8<br> <li> Maintains all other dependencies unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/watercrawl/WaterCrawl/pull/170/files#diff-9f2cf60079756e94b31dbaeb145297215236d3c0135647163c2e51b80fd81551">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

