### PR TITLE
fix: pg_isready healthcheck by user POSTGRES_USER

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -198,7 +198,7 @@ services:
     volumes:
       - ./volumes/postgres-db:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER}" ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
### **User description**
## Description
change docker-compose.yml healthcheck to use pg_isready by user POSTGRES_USER

## Related Issue
Fixes #188

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## UI Changes

## Testing
- [x] Test by docker compose logs

## Checklist
- [x] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published


___

### **PR Type**
Bug fix


___

### **Description**
- Fix pg_isready healthcheck to use POSTGRES_USER environment variable

- Ensures healthcheck runs with correct database user credentials


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pg_isready without user"] -- "add -U flag" --> B["pg_isready -U POSTGRES_USER"]
  B -- "uses env variable" --> C["Correct user authentication"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Add POSTGRES_USER to pg_isready healthcheck</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/docker-compose.yml

<ul><li>Updated PostgreSQL healthcheck command to include <code>-U ${POSTGRES_USER}</code> <br>flag<br> <li> Ensures pg_isready command authenticates with the configured database <br>user<br> <li> Fixes healthcheck failures when POSTGRES_USER differs from default <br>'postgres'</ul>


</details>


  </td>
  <td><a href="https://github.com/watercrawl/WaterCrawl/pull/189/files#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

