### PR TITLE
fix: always send tool config fields regardless of enable_as_tool state

### DIFF
--- a/frontend/src/hooks/useAgentToolConfig.ts
+++ b/frontend/src/hooks/useAgentToolConfig.ts
@@ -41,8 +41,8 @@ export const useAgentToolConfig = (
     try {
       await agentApi.update(agentId, {
         enable_as_tool: enableAsTool,
-        tool_function_name: enableAsTool ? toolFunctionName : '',
-        tool_description: enableAsTool ? toolDescription : '',
+        tool_function_name: toolFunctionName,
+        tool_description: toolDescription
       });
       toast.success(t('agents.form.toolConfigSaved'));
     } catch (error: any) {


### PR DESCRIPTION
### **User description**
- Remove conditional clearing of tool_function_name and tool_description when enable_as_tool is false
- Backend now handles empty string values appropriately when tool is disabled


___

### **PR Type**
Bug fix


___

### **Description**
- Remove conditional clearing of tool config fields in API requests

- Always send `tool_function_name` and `tool_description` values

- Backend now handles empty strings when tool is disabled


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tool Config State"] -->|Previously| B["Clear fields if disabled"]
  A -->|Now| C["Always send values"]
  B --> D["Backend receives empty strings"]
  C --> D
  D --> E["Backend handles appropriately"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useAgentToolConfig.ts</strong><dd><code>Remove conditional field clearing in tool config save</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/hooks/useAgentToolConfig.ts

<ul><li>Removed ternary conditional that cleared <code>tool_function_name</code> and <br><code>tool_description</code> when <code>enableAsTool</code> is false<br> <li> Now always sends the actual field values to the API regardless of tool <br>enabled state<br> <li> Delegates empty string handling to backend logic</ul>


</details>


  </td>
  <td><a href="https://github.com/watercrawl/WaterCrawl/pull/213/files#diff-731d103b7a80b4b5e83d216e4058f515cfb6e85ce0b472f839729a6e02b6c187">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

