### PR TITLE
fix: add cache-busting version parameter to all logo and icon assets

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico?v=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WaterCrawl.dev</title>
     <!-- Load runtime configuration before the app (no-cache) -->

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -3,12 +3,12 @@
     "short_name": "",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "/android-chrome-192x192.png?v=1",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-512x512.png",
+            "src": "/android-chrome-512x512.png?v=1",
             "sizes": "512x512",
             "type": "image/png"
         }

--- a/frontend/src/components/shared/AboutModal.tsx
+++ b/frontend/src/components/shared/AboutModal.tsx
@@ -33,7 +33,7 @@ export const AboutModal: React.FC<AboutModalProps> = ({ isOpen, onClose }) => {
         {/* Logo, Name and Version */}
         <div className="flex items-center gap-3 rounded-lg bg-muted px-3 py-2.5">
           <img
-            src={isDark ? '/logo-dark.svg' : '/logo.svg'}
+            src={isDark ? '/logo-dark.svg?v=1' : '/logo.svg?v=1'}
             alt="WaterCrawl"
             className="h-10 w-10"
           />

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -63,7 +63,7 @@ export const AdminLayout: React.FC = () => {
       {/* Mobile Sidebar */}
       <MobileSidebarContainer isOpen={sidebarOpen} onClose={closeSidebar}>
         <Sidebar
-          logo={!isDark ? '/logo.svg' : '/logo-dark.svg'}
+          logo={!isDark ? '/logo.svg?v=1' : '/logo-dark.svg?v=1'}
           logoAlt="WaterCrawl Admin"
           title={t('admin.panelTitle')}
           subtitle="Administration Panel"
@@ -79,7 +79,7 @@ export const AdminLayout: React.FC = () => {
       {/* Desktop Sidebar */}
       <DesktopSidebarContainer>
         <Sidebar
-          logo={!isDark ? '/logo.svg' : '/logo-dark.svg'}
+          logo={!isDark ? '/logo.svg?v=1' : '/logo-dark.svg?v=1'}
           logoAlt="WaterCrawl Admin"
           title={t('admin.panelTitle')}
           subtitle="Administration Panel"

--- a/frontend/src/layouts/DashboardLayout.tsx
+++ b/frontend/src/layouts/DashboardLayout.tsx
@@ -187,7 +187,7 @@ export const DashboardLayout = () => {
       {/* Mobile Sidebar */}
       <MobileSidebarContainer isOpen={sidebarOpen} onClose={closeSidebar}>
         <Sidebar
-          logo={!isDark ? '/logo.svg' : '/logo-dark.svg'}
+          logo={!isDark ? '/logo.svg?v=1' : '/logo-dark.svg?v=1'}
           logoAlt="WaterCrawl"
           title="WaterCrawl"
           titleLink="/dashboard"
@@ -205,7 +205,7 @@ export const DashboardLayout = () => {
       {/* Desktop Sidebar */}
       <DesktopSidebarContainer>
         <Sidebar
-          logo={!isDark ? '/logo.svg' : '/logo-dark.svg'}
+          logo={!isDark ? '/logo.svg?v=1' : '/logo-dark.svg?v=1'}
           logoAlt="WaterCrawl"
           title="WaterCrawl"
           titleLink="/dashboard"

--- a/frontend/src/layouts/PublicSkeleton.tsx
+++ b/frontend/src/layouts/PublicSkeleton.tsx
@@ -26,7 +26,7 @@ export const PublicSkeleton: React.FC<{ children: React.ReactNode }> = ({ childr
           <span>
             {theme === 'dark' ? (
               <img
-                src="/logo-dark.svg"
+                src="/logo-dark.svg?v=1"
                 alt="WaterCrawl"
                 className="mx-2 inline-block"
                 width={42}
@@ -34,7 +34,7 @@ export const PublicSkeleton: React.FC<{ children: React.ReactNode }> = ({ childr
               />
             ) : (
               <img
-                src="/logo.svg"
+                src="/logo.svg?v=1"
                 alt="WaterCrawl"
                 className="mx-2 inline-block"
                 width={42}


### PR DESCRIPTION
- Add ?v=1 query parameter to favicon.ico in index.html
- Add ?v=1 to android-chrome icons in site.webmanifest
- Add ?v=1 to all logo.svg and logo-dark.svg references in components and layouts
- Ensure browsers fetch updated branding assets after recent logo changes
